### PR TITLE
Fix sorting of items in RSS feed

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -42,7 +42,7 @@ class LatestEntriesFeed(Feed):
 
     def items(self, blog):
         num = getattr(settings, 'BLOG_PAGINATION_PER_PAGE', 10)
-        return blog.get_descendants()[:num]
+        return blog.get_descendants().order_by('-first_published_at')[:num]
 
     def item_title(self, item):
         return item.title


### PR DESCRIPTION
The sorting was off, maybe default sorting mechanisms have changed in the `Page` model? Or maybe something with MPTT?

Anyways, shouldn't harm to be explicit about it. I prefer `first_published_at`.