### PR TITLE
Fixed migration not being reversible

### DIFF
--- a/blog/migrations/0005_auto_20151019_1121.py
+++ b/blog/migrations/0005_auto_20151019_1121.py
@@ -52,5 +52,5 @@ class Migration(migrations.Migration):
             name='date',
             field=models.DateField(default=datetime.datetime.today, help_text='This date may be displayed on the blog post. It is not used to schedule posts to go live at a later date.', verbose_name='Post date'),
         ),
-        migrations.RunPython(default_author),
+        migrations.RunPython(default_author, reverse_code=migrations.RunPython.noop),
     ]


### PR DESCRIPTION
Migration 0005_auto_20151019_1121 is not reversible because the default_author operation had no reverse code. Since the field the operation sets data for is made in this migration, it should be safe to use noop. The error that was thrown was
`django.db.migrations.exceptions.IrreversibleError: Operation <RunPython <function default_author at 0x11292f268>> in blog.0005_auto_20151019_1121 is not reversible`

This made the entire package not able to be uninstalled because it was not able to unapply any migrations. With this small fix, I was able to unapply all migrations.